### PR TITLE
Remove www prefix.  It results in hangs during auth / token requests

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1,5 +1,5 @@
 swagger: "2.0"
-host: "www.smartmetertexas.com"
+host: "smartmetertexas.com"
 basePath: "/api"
 info:
   description: "Smart Meter Texas Documentation for Unofficial API"


### PR DESCRIPTION
Fixes https://github.com/keatontaylor/smartmetertexas-api/issues/1

Also, you might consider removing the mention of the www prefix on the wiki as well.